### PR TITLE
fix: readme hf command error

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Download our pretrained checkpoints from huggingface or modelscope using the fol
 
 ```
 # if you are using huggingface
-hf download --model 'HeartMuLa/HeartMuLaGen' --local_dir './ckpt'
-hf download --model 'HeartMuLa/HeartMuLa-oss-3B' --local_dir './ckpt/HeartMuLa-oss-3B'
-hf download --model 'HeartMuLa/HeartCodec-oss' --local_dir './ckpt/HeartCodec-oss'
+hf download --local-dir './ckpt' 'HeartMuLa/HeartMuLaGen'
+hf download --local-dir './ckpt/HeartMuLa-oss-3B' 'HeartMuLa/HeartMuLa-oss-3B'
+hf download --local-dir './ckpt/HeartCodec-oss' 'HeartMuLa/HeartCodec-oss'
 
 # if you are using modelscope
 modelscope download --model 'HeartMuLa/HeartMuLaGen' --local_dir './ckpt'


### PR DESCRIPTION
This is to fix the hugging face command error in readme.

```
$ hf download --model 'HeartMuLa/HeartMuLaGen' --local_dir './ckpt'
usage: hf <command> [<args>]
hf: error: unrecognized arguments: --model --local_dir ./ckpt
```