### PR TITLE
fix(music_generation.py): cuda device option is invalid

### DIFF
--- a/src/heartlib/pipelines/music_generation.py
+++ b/src/heartlib/pipelines/music_generation.py
@@ -228,7 +228,7 @@ class HeartMuLaGenPipeline(Pipeline):
             heartmula_path := os.path.join(pretrained_path, f"HeartMuLa-oss-{version}")
         ):
             heartmula = HeartMuLa.from_pretrained(
-                heartmula_path, dtype=dtype, quantization_config=bnb_config
+                heartmula_path, dtype=dtype, quantization_config=bnb_config, device_map=device
             )
         else:
             raise FileNotFoundError(


### PR DESCRIPTION
when device is not 'cuda:0' and ‘CUDA_VISIBLE_DEVICES’ has multiple values, the operation is 'RuntimeError'. because 'HeartMuLa' work on default 'cuda:0'