### PR TITLE
fix: improve tag conditioning with CFG increase, tag-to-description i…

### DIFF
--- a/SUPPORTED_TAGS.md
+++ b/SUPPORTED_TAGS.md
@@ -1,0 +1,192 @@
+# Supported Tags for HeartMuLa
+
+This document lists tags that have been tested and shown to have some effect on music generation. The 3B model has limited tag conditioning, so results may vary.
+
+## Tips for Better Results
+
+1. **Use CFG scale 2.0-2.5** for stronger tag following (default is now 2.5)
+2. **Put style descriptions in lyrics** if tags alone don't work - the model responds better to natural language
+3. **Format:** `tag1,tag2,tag3` (comma-separated, lowercase)
+4. **Keep it simple:** 3-5 tags work better than many tags
+5. **Unknown tags** will trigger a warning but won't break generation
+
+## Gender / Voice
+
+| Tag | Description |
+|-----|-------------|
+| `male` | Male vocalist |
+| `female` | Female vocalist |
+| `male vocal` | Male vocalist |
+| `female vocal` | Female vocalist |
+
+## Genre
+
+| Tag | Description |
+|-----|-------------|
+| `pop` | Pop music with catchy melodies |
+| `rock` | Rock with electric guitars and drums |
+| `hip-hop` | Hip-hop with rhythmic beats |
+| `r&b` | R&B with soulful vocals |
+| `electronic` | Electronic music |
+| `dance` | Dance music |
+| `edm` | Electronic dance music |
+| `jazz` | Jazz with improvisation |
+| `classical` | Classical orchestral |
+| `country` | Country music |
+| `folk` | Folk music |
+| `metal` | Heavy metal |
+| `funk` | Funky groove |
+| `soul` | Soulful music |
+| `reggae` | Reggae |
+| `blues` | Blues |
+| `indie` | Indie style |
+| `indie pop` | Indie pop |
+| `alternative` | Alternative rock |
+| `ambient` | Ambient soundscape |
+| `acoustic` | Acoustic instrumentation |
+| `ballad` | Emotional ballad |
+| `gospel` | Gospel music |
+| `trance` | Trance music |
+| `techno` | Techno |
+| `house` | House music |
+| `rap` | Rap |
+| `trap` | Trap music |
+
+### Regional Pop Styles
+
+| Tag | Description |
+|-----|-------------|
+| `j-pop` | Japanese pop |
+| `k-pop` | Korean pop |
+| `c-pop` | Chinese pop |
+| `cantopop` | Cantonese pop |
+| `mandopop` | Mandarin pop |
+| `anime` | Anime soundtrack style |
+
+## Instruments
+
+| Tag | Description |
+|-----|-------------|
+| `piano` | Featuring piano |
+| `guitar` | Featuring guitar |
+| `drums` | Prominent drums |
+| `bass` | Prominent bass |
+| `synthesizer` | Synthesizer sounds |
+| `synth` | Synthesizer sounds |
+| `strings` | String instruments |
+| `keyboard` | Keyboard |
+| `violin` | Featuring violin |
+| `orchestra` | Orchestral arrangement |
+| `pipa` | Featuring pipa |
+
+## Mood / Emotion
+
+| Tag | Description |
+|-----|-------------|
+| `happy` | Upbeat and cheerful |
+| `sad` | Melancholic |
+| `energetic` | High energy |
+| `calm` | Peaceful |
+| `relaxed` | Laid-back |
+| `romantic` | Romantic |
+| `aggressive` | Intense |
+| `melancholic` | Melancholic |
+| `dreamy` | Dreamy |
+| `hopeful` | Hopeful |
+| `cheerful` | Cheerful |
+| `peaceful` | Peaceful |
+| `warm` | Warm feeling |
+| `joyful` | Joyful |
+| `upbeat` | Upbeat |
+| `emotional` | Emotional |
+| `uplifting` | Uplifting |
+| `chill` | Chill vibes |
+| `nostalgic` | Nostalgic |
+| `mellow` | Mellow |
+| `playful` | Playful |
+| `intense` | Intense |
+| `epic` | Epic and grand |
+| `passionate` | Passionate |
+| `soft` | Soft |
+
+## Tempo / Energy
+
+| Tag | Description |
+|-----|-------------|
+| `fast` | Fast tempo |
+| `slow` | Slow tempo |
+| `heavy` | Heavy and powerful |
+| `light` | Light and airy |
+| `strong` | Strong and forceful |
+
+## Singer Timbre
+
+| Tag | Description |
+|-----|-------------|
+| `clear` | Clear vocals |
+| `raspy` | Raspy voice |
+| `smooth` | Smooth vocals |
+| `powerful` | Powerful vocals |
+| `breathy` | Breathy vocals |
+| `deep` | Deep voice |
+| `bright` | Bright vocal tone |
+| `youthful` | Youthful voice |
+
+## Scene / Context
+
+| Tag | Description |
+|-----|-------------|
+| `wedding` | Wedding music |
+| `workout` | Workout music |
+| `meditation` | Meditation music |
+| `study` | Study music |
+| `party` | Party music |
+| `club` | Club music |
+| `cafe` | Cafe ambiance |
+| `driving` | Driving music |
+| `night` | Nighttime mood |
+| `morning` | Morning mood |
+| `sunset` | Sunset mood |
+| `beach` | Beach vibes |
+| `rainy day` | Rainy day mood |
+
+## Example Tag Combinations
+
+```
+# Upbeat pop song
+pop,happy,energetic,female vocal
+
+# Chill R&B
+r&b,chill,smooth,romantic
+
+# Rock ballad
+rock,ballad,emotional,guitar
+
+# Electronic dance
+electronic,dance,energetic,synthesizer
+
+# Acoustic folk
+folk,acoustic,calm,guitar
+
+# Hip-hop
+hip-hop,rap,bass,male vocal
+```
+
+## Known Limitations
+
+1. **Genre diversity is limited** - The 3B model tends toward pop-style output regardless of tags
+2. **Some tags are ignored** - Not all tags have strong conditioning effects
+3. **Consistency varies** - The same tags may produce different results across generations
+
+## Workaround: Style in Lyrics
+
+If tags aren't working, try putting style descriptions directly in your lyrics:
+
+```
+[Style: This is an energetic rock song with electric guitars and powerful drums]
+
+[Verse]
+Your lyrics here...
+```
+
+The model often responds better to natural language descriptions in the lyrics field than to comma-separated tags.

--- a/src/heartlib/pipelines/music_generation.py
+++ b/src/heartlib/pipelines/music_generation.py
@@ -1,9 +1,11 @@
 from tokenizers import Tokenizer
 from ..heartmula.modeling_heartmula import HeartMuLa
 from ..heartcodec.modeling_heartcodec import HeartCodec
+from ..utils.tag_processor import enhance_lyrics_with_tags, get_tag_warnings
 import torch
 from typing import Dict, Any, Optional, Union
 import os
+import warnings
 from dataclasses import dataclass
 from tqdm import tqdm
 import torchaudio
@@ -181,12 +183,14 @@ class HeartMuLaGenPipeline:
         return
 
     def _sanitize_parameters(self, **kwargs):
-        preprocess_kwargs = {"cfg_scale": kwargs.get("cfg_scale", 1.5)}
+        # Default CFG increased from 1.5 to 2.5 for stronger tag conditioning
+        # Users report better tag following with higher CFG values
+        preprocess_kwargs = {"cfg_scale": kwargs.get("cfg_scale", 2.5)}
         forward_kwargs = {
             "max_audio_length_ms": kwargs.get("max_audio_length_ms", 120_000),
             "temperature": kwargs.get("temperature", 1.0),
             "topk": kwargs.get("topk", 50),
-            "cfg_scale": kwargs.get("cfg_scale", 1.5),
+            "cfg_scale": kwargs.get("cfg_scale", 2.5),
         }
         postprocess_kwargs = {
             "save_path": kwargs.get("save_path", "output.mp3"),
@@ -201,6 +205,11 @@ class HeartMuLaGenPipeline:
             with open(tags, encoding="utf-8") as fp:
                 tags = fp.read()
         assert isinstance(tags, str), f"tags must be a string, but got {type(tags)}"
+
+        # Validate tags and warn about unknown ones
+        tag_warnings = get_tag_warnings(tags)
+        for warning in tag_warnings:
+            warnings.warn(warning, UserWarning)
 
         tags = tags.lower()
         # encapsulate with special <tag> and </tag> tokens
@@ -230,6 +239,11 @@ class HeartMuLaGenPipeline:
         assert isinstance(
             lyrics, str
         ), f"lyrics must be a string, but got {type(lyrics)}"
+        
+        # Enhance lyrics with tag descriptions for better style conditioning
+        # The model responds better to natural language in lyrics than to tags
+        lyrics = enhance_lyrics_with_tags(lyrics, inputs["tags"])
+        
         lyrics = lyrics.lower()
 
         lyrics_ids = self.text_tokenizer.encode(lyrics).ids

--- a/src/heartlib/utils/__init__.py
+++ b/src/heartlib/utils/__init__.py
@@ -1,0 +1,13 @@
+from .tag_processor import (
+    tags_to_description,
+    enhance_lyrics_with_tags,
+    validate_tags,
+    KNOWN_TAGS,
+)
+
+__all__ = [
+    "tags_to_description",
+    "enhance_lyrics_with_tags",
+    "validate_tags",
+    "KNOWN_TAGS",
+]

--- a/src/heartlib/utils/tag_processor.py
+++ b/src/heartlib/utils/tag_processor.py
@@ -1,0 +1,253 @@
+"""
+Tag processing utilities for HeartMuLa.
+
+This module provides utilities to improve tag conditioning by:
+1. Converting comma-separated tags to natural language descriptions
+2. Validating tags against known working tags
+3. Enhancing lyrics with style descriptions for better conditioning
+
+The 3B model responds better to natural language style descriptions in the lyrics
+than to comma-separated tags. This module exploits that behavior.
+"""
+
+from typing import List, Set, Tuple
+
+# Tag-to-description mappings for natural language injection
+TAG_TO_DESCRIPTION = {
+    # Genre mappings
+    "pop": "pop music with catchy melodies",
+    "rock": "rock music with electric guitars and drums",
+    "hip-hop": "hip-hop with rhythmic beats and flow",
+    "hip hop": "hip-hop with rhythmic beats and flow",
+    "r&b": "R&B with soulful vocals and smooth grooves",
+    "rnb": "R&B with soulful vocals and smooth grooves",
+    "electronic": "electronic music with synthesizers",
+    "dance": "dance music with driving beats",
+    "edm": "electronic dance music",
+    "jazz": "jazz with improvisation and swing",
+    "classical": "classical orchestral arrangement",
+    "country": "country music with acoustic guitar",
+    "folk": "folk music with acoustic instruments",
+    "metal": "heavy metal with distorted guitars",
+    "funk": "funky groove with bass and rhythm",
+    "soul": "soulful music with emotional vocals",
+    "reggae": "reggae with offbeat rhythms",
+    "blues": "blues with expressive guitar",
+    "indie": "indie style",
+    "indie pop": "indie pop style",
+    "alternative": "alternative rock style",
+    "ambient": "ambient atmospheric soundscape",
+    "acoustic": "acoustic instrumentation",
+    "ballad": "emotional ballad",
+    "gospel": "gospel music",
+    "christian": "christian music",
+    "anime": "anime soundtrack style",
+    "j-pop": "Japanese pop style",
+    "k-pop": "Korean pop style",
+    "c-pop": "Chinese pop style",
+    "cantopop": "Cantonese pop style",
+    "mandopop": "Mandarin pop style",
+    "trance": "trance music with hypnotic beats",
+    "techno": "techno with driving electronic beats",
+    "house": "house music with four-on-the-floor beat",
+    "rap": "rap with rhythmic vocal delivery",
+    "trap": "trap music with heavy bass",
+    
+    # Mood mappings
+    "happy": "upbeat and cheerful",
+    "sad": "melancholic and emotional",
+    "energetic": "high energy and exciting",
+    "calm": "peaceful and relaxing",
+    "relaxed": "laid-back and chill",
+    "romantic": "romantic and intimate",
+    "aggressive": "intense and powerful",
+    "melancholic": "melancholic mood",
+    "dreamy": "dreamy and ethereal",
+    "hopeful": "hopeful and uplifting",
+    "sentimental": "sentimental feeling",
+    "gentle": "gentle and soft",
+    "cheerful": "cheerful and bright",
+    "peaceful": "peaceful atmosphere",
+    "warm": "warm feeling",
+    "sweet": "sweet and tender",
+    "joyful": "joyful and celebratory",
+    "solemn": "solemn and serious",
+    "upbeat": "upbeat tempo",
+    "reflective": "reflective and thoughtful",
+    "emotional": "deeply emotional",
+    "confident": "confident and bold",
+    "uplifting": "uplifting and inspiring",
+    "chill": "chill vibes",
+    "nostalgic": "nostalgic feeling",
+    "introspective": "introspective mood",
+    "mellow": "mellow and smooth",
+    "playful": "playful and fun",
+    "intense": "intense and dramatic",
+    "rebellious": "rebellious attitude",
+    "epic": "epic and grand",
+    "passionate": "passionate expression",
+    "soft": "soft and delicate",
+    "gloomy": "dark and gloomy",
+    
+    # Tempo/energy mappings
+    "fast": "fast tempo",
+    "slow": "slow tempo",
+    "fast tempo": "fast tempo",
+    "slow tempo": "slow tempo",
+    "heavy": "heavy and powerful",
+    "light": "light and airy",
+    "strong": "strong and forceful",
+    
+    # Instrument mappings
+    "piano": "featuring piano",
+    "guitar": "featuring guitar",
+    "drums": "with prominent drums",
+    "synthesizer": "with synthesizer sounds",
+    "synth": "with synthesizer sounds",
+    "strings": "with string instruments",
+    "bass": "with prominent bass",
+    "keyboard": "with keyboard",
+    "violin": "featuring violin",
+    "orchestra": "with orchestral arrangement",
+    "pipa": "featuring pipa",
+    
+    # Voice mappings
+    "male vocal": "sung by a male vocalist",
+    "female vocal": "sung by a female vocalist",
+    "male voice": "sung by a male vocalist",
+    "female voice": "sung by a female vocalist",
+    "male": "male vocalist",
+    "female": "female vocalist",
+    
+    # Singer timbre
+    "clear": "clear vocals",
+    "raspy": "raspy voice",
+    "smooth": "smooth vocals",
+    "powerful": "powerful vocals",
+    "breathy": "breathy vocals",
+    "deep": "deep voice",
+    "bright": "bright vocal tone",
+    "youthful": "youthful voice",
+    "mature": "mature voice",
+}
+
+# Set of all known tags that have shown some effect
+KNOWN_TAGS: Set[str] = set(TAG_TO_DESCRIPTION.keys())
+
+# Additional tags from community testing (Issue #9)
+KNOWN_TAGS.update({
+    # Scenes
+    "driving", "cafe", "relaxing", "meditation", "night", "alone", "walking",
+    "travel", "study", "wedding", "workout", "dating", "bedroom", "home",
+    "rainy day", "evening", "club", "reflection", "church", "sunset", "gaming",
+    "reading", "morning", "street", "thinking", "shopping", "worship",
+    "campfire", "movie", "playground", "funeral", "party", "beach",
+    
+    # Topics
+    "love", "relationship", "longing", "loss", "regret", "life", "hope",
+    "breakup", "heartbreak", "memory", "farewell", "loneliness", "youth",
+    "nature", "romance", "dream", "faith", "friendship", "lost", "rebellion",
+    "encouragement", "freedom", "struggle", "self-reflection", "missing",
+    "inspiration", "happiness", "courage", "reminiscence", "confess",
+})
+
+
+def tags_to_description(tags: str) -> str:
+    """
+    Convert comma-separated tags to a natural language description.
+    
+    The model responds better to natural language descriptions than to
+    comma-separated tags. This function converts tags like "rock,energetic"
+    into "[Style: rock music with electric guitars and drums, high energy and exciting]"
+    
+    Args:
+        tags: Comma-separated tag string (e.g., "rock,energetic,guitar")
+        
+    Returns:
+        Natural language description string, or empty string if no tags
+    """
+    if not tags or not tags.strip():
+        return ""
+    
+    tag_list = [t.strip().lower() for t in tags.split(",") if t.strip()]
+    if not tag_list:
+        return ""
+    
+    descriptions = []
+    for tag in tag_list:
+        if tag in TAG_TO_DESCRIPTION:
+            descriptions.append(TAG_TO_DESCRIPTION[tag])
+        else:
+            # Unknown tag - include as-is with "style" suffix
+            descriptions.append(f"{tag} style")
+    
+    if descriptions:
+        return "[Style: " + ", ".join(descriptions) + "]\n\n"
+    return ""
+
+
+def enhance_lyrics_with_tags(lyrics: str, tags: str) -> str:
+    """
+    Prepend tag descriptions to lyrics for better style conditioning.
+    
+    This exploits the model's tendency to extract style information from
+    the lyrics field rather than the tags field.
+    
+    Args:
+        lyrics: The original lyrics text
+        tags: Comma-separated tag string
+        
+    Returns:
+        Lyrics with style description prepended
+    """
+    description = tags_to_description(tags)
+    return description + lyrics
+
+
+def validate_tags(tags: str) -> Tuple[List[str], List[str]]:
+    """
+    Validate tags against known working tags.
+    
+    Args:
+        tags: Comma-separated tag string
+        
+    Returns:
+        Tuple of (known_tags, unknown_tags) lists
+    """
+    if not tags or not tags.strip():
+        return [], []
+    
+    tag_list = [t.strip().lower() for t in tags.split(",") if t.strip()]
+    
+    known = []
+    unknown = []
+    
+    for tag in tag_list:
+        if tag in KNOWN_TAGS:
+            known.append(tag)
+        else:
+            unknown.append(tag)
+    
+    return known, unknown
+
+
+def get_tag_warnings(tags: str) -> List[str]:
+    """
+    Get warning messages for unknown tags.
+    
+    Args:
+        tags: Comma-separated tag string
+        
+    Returns:
+        List of warning messages
+    """
+    _, unknown = validate_tags(tags)
+    warnings = []
+    
+    for tag in unknown:
+        warnings.append(
+            f"Warning: Tag '{tag}' is not in the known working tags list. "
+            "It may not affect the output. See SUPPORTED_TAGS.md for guidance."
+        )
+    
+    return warnings


### PR DESCRIPTION
…njection, and validation

This PR addresses the widely reported issue that genre/style tags have minimal effect on the 3B model's output. Changes include:

1. Increase default CFG scale from 1.5 to 2.5
   - Users report better tag following with higher CFG values (2.0-2.5)
   - The model's conditioning becomes stronger with higher CFG

2. Tag-to-description injection
   - Converts comma-separated tags to natural language descriptions
   - Prepends style descriptions to lyrics field
   - Exploits the model's better understanding of natural language vs tags
   - Example: 'rock,energetic' -> '[Style: rock music with electric guitars...]'

3. Tag validation warnings
   - Warns users when they use tags not in the known working list
   - Helps users understand which tags are likely to have an effect

4. SUPPORTED_TAGS.md documentation
   - Documents all known working tags by category
   - Includes tips for better results
   - Explains the workaround of putting style in lyrics

These changes work around the model's limited tag conditioning without requiring retraining or architectural changes.