### PR TITLE
Add temperature curve support

### DIFF
--- a/src/heartlib/utils/__init__.py
+++ b/src/heartlib/utils/__init__.py
@@ -1,0 +1,12 @@
+"""Utility functions for HeartLib."""
+from .temperature_schedule import (
+    TemperatureSpec,
+    parse_temperature_spec,
+    compute_temperature,
+)
+
+__all__ = [
+    "TemperatureSpec",
+    "parse_temperature_spec",
+    "compute_temperature",
+]

--- a/src/heartlib/utils/temperature_schedule.py
+++ b/src/heartlib/utils/temperature_schedule.py
@@ -1,0 +1,80 @@
+"""Temperature scheduling utility
+
+This module helps adjust temperature throughout an inference run.
+
+The purpose of this is to allow inference to with a higher temperature and gradually reduce it to mitigate precision loss accumulation for longer runs.
+
+"""
+from typing import Union, Tuple, Dict, Any
+import math
+
+TemperatureSpec = Union[float, Tuple[float, float], Dict[str, Any]]
+
+
+def parse_temperature_spec(temp_spec: TemperatureSpec) -> Dict[str, Any]:
+    """
+    Parse temperature specification into normalized config.
+
+    Args:
+        temp_spec: Either a float, tuple (start, end), or dict with keys:
+            - start: Starting temperature
+            - end: Ending temperature
+            - schedule: "linear" or "cosine" (default: "linear")
+
+    Returns:
+        Dict with keys: start, end, schedule, is_dynamic
+    """
+    if isinstance(temp_spec, (int, float)):
+        return {
+            "start": float(temp_spec),
+            "end": float(temp_spec),
+            "schedule": "linear",
+            "is_dynamic": False,
+        }
+    elif isinstance(temp_spec, tuple) and len(temp_spec) == 2:
+        return {
+            "start": float(temp_spec[0]),
+            "end": float(temp_spec[1]),
+            "schedule": "linear",
+            "is_dynamic": True,
+        }
+    elif isinstance(temp_spec, dict):
+        start = float(temp_spec.get("start", 1.0))
+        end = float(temp_spec.get("end", start))
+        return {
+            "start": start,
+            "end": end,
+            "schedule": temp_spec.get("schedule", "linear"),
+            "is_dynamic": start != end,
+        }
+    else:
+        raise ValueError(f"Invalid temperature spec: {temp_spec}")
+
+
+def compute_temperature(
+    progress: float,
+    start: float,
+    end: float,
+    schedule: str = "linear",
+) -> float:
+    """
+    Compute temperature at a given progress point.
+
+    Args:
+        progress: Generation progress from 0.0 to 1.0
+        start: Starting temperature
+        end: Ending temperature
+        schedule: Interpolation method ("linear" or "cosine")
+
+    Returns:
+        Interpolated temperature value
+    """
+    progress = max(0.0, min(1.0, progress))  # Clamp to [0, 1]
+
+    if schedule == "linear":
+        return start + (end - start) * progress
+    elif schedule == "cosine":
+        # Cosine annealing: smooth transition
+        return end + (start - end) * 0.5 * (1 + math.cos(math.pi * progress))
+    else:
+        raise ValueError(f"Unknown schedule: {schedule}. Use 'linear' or 'cosine'.")


### PR DESCRIPTION
Adds a temperature_curve utility and allows for passing some additional parameters to better control temperature during inferencing. This allows the temperature to interpolate (currently linear or cosine) over the course of generation. This helps to mitigate precision loss accumulation on longer runs or with extreme `topk` and `cfg_scale` values by starting warm and cooling down.

Added to `examples/run_music_generation.py`
 - `--temperature_end ` (default: none) If set, will adjust the temperature throughout the run from the starting value in `--temperature` to this value according to the set schedule.
 - `--temperature_schedule` (default: "linear") Will use this schedule to define the temperature curve. Currently implemented curves are "linear" or "cosine".

![Timeline 1](https://github.com/user-attachments/assets/c60c1abd-5194-48c6-867f-514785bf979c)
