### PR TITLE
Add custom seed support

### DIFF
--- a/examples/run_music_generation.py
+++ b/examples/run_music_generation.py
@@ -48,6 +48,8 @@ def parse_args():
     parser.add_argument("--mula_dtype", type=str2dtype, default="bfloat16")
     parser.add_argument("--codec_dtype", type=str2dtype, default="float32")
     parser.add_argument("--lazy_load", type=str2bool, default=False)
+    parser.add_argument("--seed", type=int, default=None,
+                        help="Random seed for reproducibility (default: random)")
     return parser.parse_args()
 
 
@@ -67,7 +69,7 @@ if __name__ == "__main__":
         lazy_load=args.lazy_load,
     )
     with torch.no_grad():
-        pipe(
+        result = pipe(
             {
                 "lyrics": args.lyrics,
                 "tags": args.tags,
@@ -77,5 +79,7 @@ if __name__ == "__main__":
             topk=args.topk,
             temperature=args.temperature,
             cfg_scale=args.cfg_scale,
+            seed=args.seed,
         )
     print(f"Generated music saved to {args.save_path}")
+    print(f"Seed used: {result['seed']}")


### PR DESCRIPTION
Adds a `--seed` argument to the example script for deterministic output.

If no seed is provided (default) a random one is generated and printed so that runs can be reproduced given `--seed`, `--cfg_scale`, `--topk` and `--temperature` are identical between runs.