### PR TITLE
Fix type error on lyrics transcription README.md file

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,7 +3,7 @@
 Download checkpoint using any of the following command:
 ```
 hf download --local-dir './ckpt/HeartTranscriptor-oss' 'HeartMuLa/HeartTranscriptor-oss' 
-modelscope download --model 'HeartMuLa/HeartTranscriptor-oss' --local-dir './ckpt/HeartTranscriptor-oss'
+modelscope download --model 'HeartMuLa/HeartTranscriptor-oss' --local_dir './ckpt/HeartTranscriptor-oss'
 ```
 
 ```


### PR DESCRIPTION
I tried to run it locally and noticed the typo, damn those sneaky dashes.