### PR TITLE
Size and slice the backbone KV cache (RTF 3.65 -> 1.05 on 30s generations)

### DIFF
--- a/src/heartlib/heartmula/modeling_heartmula.py
+++ b/src/heartlib/heartmula/modeling_heartmula.py
@@ -6,6 +6,8 @@ import torch
 import torch.nn as nn
 import torchtune
 from torchtune.models import llama3_2
+from torchtune.modules.common_utils import delete_kv_caches
+from typing import Optional
 
 
 def llama3_2_3B() -> torchtune.modules.transformer.TransformerDecoder:
@@ -87,6 +89,10 @@ def _prepare_transformer(model):
     return model, embed_dim
 
 
+def _round_up(value: int, multiple: int) -> int:
+    return -(-value // multiple) * multiple
+
+
 def _create_causal_mask(seq_len: int, device: torch.device):
     return torch.tril(torch.ones(seq_len, seq_len, dtype=torch.bool, device=device))
 
@@ -152,17 +158,46 @@ class HeartMuLa(PreTrainedModel):
         self.muq_linear = nn.Linear(config.muq_dim, backbone_dim)
         self.post_init()
 
-    def setup_caches(self, max_batch_size: int):
+    def setup_caches(self, max_batch_size: int, max_seq_len: Optional[int] = None):
+        """Allocate the KV caches.
+
+        Args:
+            max_batch_size: Batch size the caches must hold.
+            max_seq_len: Longest position the backbone will be asked to attend
+                to, i.e. prompt length plus the number of frames to generate.
+                Defaults to the model's full context.
+
+        Sizing this to the actual request matters a lot. torchtune's KVCache
+        hands the *whole* cache tensor to attention rather than a view of the
+        filled prefix, so every decode step reads all `max_seq_len` positions
+        and softmaxes over them, only to have the causal mask discard the
+        unwritten tail. On a 2.8B backbone that is 1.75 GB of KV traffic per
+        frame at the full 8192 context. Measured on gfx1151, one backbone
+        forward: 248 ms at 8192, 150 ms at 4096, 75 ms at 1024. The output is
+        unchanged -- the positions dropped were already masked out.
+        """
         dtype = next(self.parameters()).dtype
         device = next(self.parameters()).device
 
-        try:
-            self.reset_caches()
-        except RuntimeError:
-            pass
+        backbone_max_seq_len = self.backbone.max_seq_len
+        if max_seq_len is not None:
+            # Round up: a ragged cache length buys nothing and complicates
+            # nothing, but a tidy one keeps kernel shapes predictable.
+            requested = min(_round_up(max_seq_len, 128), self.backbone.max_seq_len)
+            backbone_max_seq_len = max(requested, 128)
+
+        # reset_caches() only zeroes existing caches; it cannot resize them, and
+        # torchtune refuses (with a warning, not an error) to set up caches that
+        # already exist. Delete them so a new length actually takes effect.
+        if self.backbone.caches_are_enabled():
+            delete_kv_caches(self.backbone)
+        if self.decoder.caches_are_enabled():
+            delete_kv_caches(self.decoder)
 
         with device:
-            self.backbone.setup_caches(max_batch_size, dtype)
+            self.backbone.setup_caches(
+                max_batch_size, dtype, decoder_max_seq_len=backbone_max_seq_len
+            )
             self.decoder.setup_caches(
                 max_batch_size,
                 dtype,
@@ -171,7 +206,7 @@ class HeartMuLa(PreTrainedModel):
 
         self.register_buffer(
             "backbone_causal_mask",
-            _create_causal_mask(self.backbone.max_seq_len, device),
+            _create_causal_mask(backbone_max_seq_len, device),
         )
         self.register_buffer(
             "decoder_causal_mask",

--- a/src/heartlib/heartmula/modeling_heartmula.py
+++ b/src/heartlib/heartmula/modeling_heartmula.py
@@ -6,8 +6,55 @@ import torch
 import torch.nn as nn
 import torchtune
 from torchtune.models import llama3_2
+from torchtune.modules import KVCache
 from torchtune.modules.common_utils import delete_kv_caches
-from typing import Optional
+from typing import Optional, Tuple
+
+
+class _PrefixKVCache(KVCache):
+    """A KVCache that hands attention only the positions actually written.
+
+    torchtune's ``KVCache.update`` returns the whole cache tensor, so a decode
+    step attends over every *allocated* position and leans on the causal mask
+    to throw the unwritten tail away. Cost is therefore pinned at the worst
+    case from the very first frame. Returning a view of the filled prefix makes
+    it grow with how far into the song we actually are.
+
+    The fill level is tracked as a Python int rather than read back from
+    ``cache_pos``, which lives on the GPU: reading that would force a device
+    sync in each of the backbone's 28 layers, on every frame.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.filled = 0
+
+    def reset(self) -> None:
+        super().reset()
+        self.filled = 0
+
+    def update(
+        self, k_val: torch.Tensor, v_val: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        k_out, v_out = super().update(k_val, v_val)
+        self.filled += k_val.shape[2]
+        return k_out[:, :, : self.filled], v_out[:, :, : self.filled]
+
+
+def _install_prefix_caches(model) -> None:
+    """Swap the caches torchtune just built for prefix-slicing ones."""
+    for layer in model.layers:
+        old = layer.attn.kv_cache
+        if old is None or isinstance(old, _PrefixKVCache):
+            continue
+        batch_size, num_heads, max_seq_len, head_dim = old.k_cache.shape
+        layer.attn.kv_cache = _PrefixKVCache(
+            batch_size=batch_size,
+            max_seq_len=max_seq_len,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            dtype=old.k_cache.dtype,
+        ).to(old.k_cache.device)
 
 
 def llama3_2_3B() -> torchtune.modules.transformer.TransformerDecoder:
@@ -198,6 +245,9 @@ class HeartMuLa(PreTrainedModel):
             self.backbone.setup_caches(
                 max_batch_size, dtype, decoder_max_seq_len=backbone_max_seq_len
             )
+            # Backbone only: the decoder's cache is 8 positions deep, so there
+            # is nothing to save there.
+            _install_prefix_caches(self.backbone)
             self.decoder.setup_caches(
                 max_batch_size,
                 dtype,
@@ -227,7 +277,11 @@ class HeartMuLa(PreTrainedModel):
         b, s, _ = tokens.size()
 
         assert self.backbone.caches_are_enabled(), "backbone caches are not enabled"
-        curr_backbone_mask = _index_causal_mask(self.backbone_causal_mask, input_pos)
+        # The prefix cache will hand attention only the first `attended`
+        # positions, so the mask has to be narrowed to match.
+        curr_backbone_mask = self.backbone_causal_mask[
+            input_pos, : self._backbone_attended(s)
+        ]
 
         uncond_mask = None
         if cfg_scale > 1.0 and b > 1:
@@ -303,6 +357,14 @@ class HeartMuLa(PreTrainedModel):
             curr_pos = curr_pos[:, -1:] + 1
 
         return curr_sample
+
+    def _backbone_attended(self, seq_len: int) -> int:
+        """Number of cache positions this forward will actually attend over."""
+        cache = self.backbone.layers[0].attn.kv_cache
+        if isinstance(cache, _PrefixKVCache):
+            return cache.filled + seq_len
+        # Stock KVCache returns the whole tensor; the mask must span it.
+        return self.backbone_causal_mask.shape[0]
 
     def reset_caches(self):
         self.backbone.reset_caches()

--- a/src/heartlib/pipelines/music_generation.py
+++ b/src/heartlib/pipelines/music_generation.py
@@ -279,8 +279,14 @@ class HeartMuLaGenPipeline:
         prompt_pos = model_inputs["pos"].to(self.mula_device)
         frames = []
 
+        max_audio_frames = max_audio_length_ms // 80
+
         bs_size = 2 if cfg_scale != 1.0 else 1
-        self.mula.setup_caches(bs_size)
+        # Size the KV cache to this request rather than the model's full 8192
+        # context: attention reads every allocated position on every frame.
+        self.mula.setup_caches(
+            bs_size, max_seq_len=prompt_tokens.shape[1] + max_audio_frames + 1
+        )
         with torch.autocast(device_type=self.mula_device.type, dtype=self.mula_dtype):
             curr_token = self.mula.generate_frame(
                 tokens=prompt_tokens,
@@ -310,8 +316,6 @@ class HeartMuLaGenPipeline:
             )
             padded_token_mask[..., -1] = False
             return padded_token, padded_token_mask
-
-        max_audio_frames = max_audio_length_ms // 80
 
         for i in tqdm(range(max_audio_frames)):
             curr_token, curr_token_mask = _pad_audio_token(curr_token)


### PR DESCRIPTION
## Summary

The backbone spends most of every decode frame reading KV cache entries that the causal mask then throws away. Two commits fix that, and the generation loop gets ~2.8x faster on a 30-second request and ~2.3x on the 4-minute default.

Neither change is hardware-specific and neither changes what the model computes.

## The problem

Profiling one decode frame put **84.7% of the time in the backbone** (247 ms of 292 ms) against 41 ms for all seven decoder passes — despite both using the same layer shape. Effective memory bandwidth was 28 GB/s on a part capable of ~256 GB/s, so this was not a bandwidth wall.

torchtune's `KVCache.update` returns the whole cache tensor rather than a view of the filled prefix:

```python
k_out = self.k_cache        # (batch, heads, max_seq_len, head_dim)
```

`HeartMuLa.setup_caches` allocated that at the model's full 8192-token context no matter how much audio was requested. Every frame therefore read the entire cache and softmaxed over 8192 positions, only for the causal mask to discard the unwritten tail.

## The changes

**1. Size the cache to the request.** `setup_caches` takes `max_seq_len`; the pipeline passes `prompt_len + max_audio_frames + 1`.

**2. Attend only over the filled prefix.** `_PrefixKVCache` returns a view of the positions actually written, and `generate_frame` narrows the causal mask to match. Cost now tracks how far into the song we are rather than how long the song was allowed to be. The fill level is a Python `int` rather than `KVCache.size`, which lives on the GPU — reading it would mean a device sync in each of the 28 backbone layers, every frame.

Commit 1 also fixes a latent bug: calling `setup_caches` twice previously hit torchtune's `Key value caches are already setup ... Skipping` warning and silently kept the old shape. The caches are now deleted before being rebuilt.

## Measurements

Backbone forward, single call:

| KV cache length | before | after commit 1 | after commit 2 |
|---|---|---|---|
| full 8192 context | 248 ms | — | — |
| sized 4096 (~4 min) | — | 150 ms | 60 ms |
| sized 1024 (~30 s) | — | 75 ms | 60 ms |

End to end, generation loop (12.5 Hz frame rate, so RTF 1.0 = 12.5 it/s):

| | 30 s of audio | 4-minute default |
|---|---|---|
| before | 3.42 it/s — RTF 3.65 | 3.42 it/s — RTF 3.65 |
| commit 1 | 9.07 it/s — RTF 1.10 | 5.69 it/s — RTF 1.76 |
| commit 2 | **9.53 it/s — RTF 1.05** | **7.78 it/s — RTF 1.61** |

Hardware: Radeon 8060S (Ryzen AI MAX+ 395, gfx1151), torch 2.9.1+rocm7.13.0, HeartMuLa-oss-3B-happy-new-year + HeartCodec-oss-20260123. A CUDA run reads the same dead KV, so it should see a comparable improvement — I do not have NVIDIA hardware to confirm the exact figures.

## Correctness

The positions that are no longer read were already masked out, so both changes are mathematically no-ops. Verified in fp32 against the previous behaviour, over a prefill plus eight decode steps with identical forced inputs:

| | max abs logit diff | relative | argmax | top-50 set |
|---|---|---|---|---|
| commit 1 | 6.3e-5 | 1.1e-5 | identical | identical |
| commit 2 | 8.9e-5 | 1.6e-5 | identical | identical |

on a logit scale of 5.6.

In bf16 the same comparison drifts by ~0.2, which is accumulation-order noise from summing 8192 versus ~768 terms; top-k sampling amplifies that into a different but equally valid sample, the same way any non-deterministic GPU run does. Audio statistics are unchanged across full generations (RMS 0.1418 before, 0.1414 after).

## Provenance

These changes were found and written by an AI assistant (Claude, via Claude Code) while I was maintaining a ROCm/AMD fork of heartlib and profiling its inference speed. The ROCm-specific work is not part of this PR — only the two backend-independent optimizations are. All measurements quoted above were run on real hardware, and the fp32 equivalence checks were run before and after each change.

Happy to adjust anything, split further, or add whatever tests you would want to see for this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
